### PR TITLE
fix/change-article-link-styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The resulting site will be located at `http://localhost:1313`. Hugo server comes
 
 ## Deployment
 
-We use Github Pages to host the site, with Cloudfare handling the reverse proxy responsibilities.
+We use Github Pages to host the site, with Cloudflare handling the reverse proxy responsibilities.
 
 ### Building the site prior to pushing
 For your changes to be reflected, you need to rebuild the site prior to pushing up your changes. To rebuild the production site, run:
@@ -44,13 +44,13 @@ There should never be any content embedded directly in the HTML. All content for
 
 ### Site Pages
 
-A site page is considered one of the main naviagatable pages (e.g. `/blog` or `/services`). The content for these pages is derrived from the `_index.md` file in the respective folder in the `/content` directory.
+A site page is considered one of the main navigable pages (e.g. `/blog` or `/services`). The content for these pages is derived from the `_index.md` file in the respective folder in the `/content` directory.
 
 For example, the `/services` page's content can be found in `/content/services/_index.md`
 
 ### Case Studies
 
-A case study is an overview of our engagment with a client. The content for these pages is sourced from the name of the casestudy (e.g. `staples.md`), which can be found in the  `/content/work` directory.
+A case study is an overview of our engagement with a client. The content for these pages is sourced from the name of the case study (e.g. `staples.md`), which can be found in the  `/content/work` directory.
 
 #### How to create a new case study
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -152,7 +152,7 @@ a:hover {
 
 /* Article (Blog/CaseStudy) Font */
 
-/* HelveticaNueue way easier to read in paragraphs (print) */
+/* Helvetica Neue way easier to read in paragraphs (print) */
 
 article {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -196,7 +196,7 @@ article .highlight pre {
 }
 
 article a {
-    color: #666;
+    text-decoration: underline;
     font-weight: 400;
 }
 
@@ -214,6 +214,7 @@ article ol {
 
 article a:hover {
     color: var(--mesh-blue);
+    text-decoration: underline;
 }
 
 article img,
@@ -1282,7 +1283,7 @@ footer .nav-link {
 
 .work .primary-section .products .case-study-card,
 .work .primary-section .products .product-shot {
-    marign: 0;
+    margin: 0;
     width: 100%;
 }
 
@@ -1292,7 +1293,6 @@ footer .nav-link {
 
 .work .primary-section .product-shot img {
     box-shadow: 0px -3px 10px rgba(0, 0, 0, 0.4);
-    ;
 }
 
 .work .products .row {


### PR DESCRIPTION
Fixing some typos, changing the styling for links in articles so that they stand out a bit more

## Before:
![before](https://user-images.githubusercontent.com/1719443/36749733-7fe621ae-1bb0-11e8-944d-44818560595b.png)

## After:
![after](https://user-images.githubusercontent.com/1719443/36749746-84cba5ea-1bb0-11e8-921d-3b91959cab0c.png)
